### PR TITLE
Install secp256k1 build dependencies for backend image

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -6,6 +6,12 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 
 COPY backend/requirements.txt ./
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        pkg-config \
+        libsecp256k1-dev \
+    && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY backend/ ./


### PR DESCRIPTION
## Summary
- install build-essential, pkg-config, and libsecp256k1-dev in the backend Docker image so secp256k1 can build successfully

## Testing
- docker compose build backend *(fails in CI environment: docker command not available)*

------
https://chatgpt.com/codex/tasks/task_e_68dbef1b3ca08328bd2b2590f321ab4c