### PR TITLE
Add custom Nginx config for frontend

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS build
+FROM node:18-alpine as build
 
 WORKDIR /app
 COPY frontend/package*.json ./
@@ -8,5 +8,6 @@ RUN npm run build
 
 FROM nginx:latest
 COPY --from=build /app/dist /usr/share/nginx/html
+COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,5 +1,33 @@
-FROM nginx:latest
-COPY --from=build /app/dist /usr/share/nginx/html
-COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
-EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]
+server {
+    listen 80;
+
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # React (SPA): siempre devolver index.html si no existe archivo
+    location / {
+        try_files $uri /index.html;
+    }
+
+    # Proxy al backend (FastAPI)
+    location /schedule {
+        proxy_pass http://backend:8000/schedule;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    location /scheduled {
+        proxy_pass http://backend:8000/scheduled;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # Opcional: proxy genérico para /api/*
+    location /api/ {
+        proxy_pass http://backend:8000/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}


### PR DESCRIPTION
## Summary
- add a custom nginx configuration for the frontend container to handle SPA routing and backend proxies
- update the frontend Dockerfile to copy the configuration into the nginx image

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc00c6d3cc8328a27f67723f175458