### PR TITLE
Add Amber Bunker remote signer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ npm install
 npm run dev  # available at http://localhost:5173
 ```
 
-Connect a NIP-05 compatible extension (such as Alby) to authorize the frontend. Draft your note, choose a future publication date, and the frontend will sign the event locally and send it to the backend.
+Connect a NIP-05 compatible extension (such as Alby) **or** paste an Amber Bunker link when prompted to authorize the frontend. Draft your note, choose a future publication date, and the frontend will sign the event locally (via extension or Bunker remote signer) and send it to the backend.
 
 ---
 
@@ -119,7 +119,7 @@ Shared volumes ensure the backend API and the worker share the same database and
 
 1. Start the backend API and publisher worker.
 2. Run `npm run dev` in the frontend and open it in your browser.
-3. Connect a NIP-05 extension and approve the request for your public key.
+3. Connect a NIP-05 extension (or paste a Bunker link and approve it in Amber) to share your public key.
 4. Write a note, pick a future datetime, and schedule it.
 5. Wait for the worker to publish the event, then confirm it through a Nostr client such as [iris.to](https://iris.to) or [snort.social](https://snort.social).
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,28 +1,150 @@
 // App.jsx
-import React from "react";
+import React, {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import ComposeForm from "./components/ComposeForm";
 import ScheduledList from "./components/ScheduledList";
+import BunkerClient from "./lib/bunkerClient";
+
+export const SignerContext = createContext(null);
 
 function App() {
+  const [pubkey, setPubkey] = useState("");
+  const [signerType, setSignerType] = useState(null);
+  const [extensionPubkey, setExtensionPubkey] = useState("");
+  const bunkerClientRef = useRef(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function detectExtension() {
+      if (!window?.nostr) {
+        return;
+      }
+      try {
+        const pk = await window.nostr.getPublicKey();
+        if (!cancelled) {
+          setExtensionPubkey(pk);
+          setSignerType((prev) => prev ?? "extension");
+          setPubkey((current) => current || pk);
+        }
+      } catch (err) {
+        console.warn("Unable to retrieve public key from extension", err);
+      }
+    }
+    detectExtension();
+    return () => {
+      cancelled = true;
+      bunkerClientRef.current?.disconnect();
+    };
+  }, []);
+
+  const connectBunker = useCallback(async (link, options = {}) => {
+    const client = new BunkerClient();
+    try {
+      const userPubkey = await client.connect(link, options);
+      bunkerClientRef.current?.disconnect();
+      bunkerClientRef.current = client;
+      setSignerType("bunker");
+      setPubkey(userPubkey);
+      return userPubkey;
+    } catch (err) {
+      client.disconnect();
+      throw err;
+    }
+  }, []);
+
+  const disconnectBunker = useCallback(() => {
+    if (bunkerClientRef.current) {
+      bunkerClientRef.current.disconnect();
+      bunkerClientRef.current = null;
+    }
+    if (extensionPubkey) {
+      setSignerType("extension");
+      setPubkey(extensionPubkey);
+    } else {
+      setSignerType(null);
+      setPubkey("");
+    }
+  }, [extensionPubkey]);
+
+  const useExtension = useCallback(() => {
+    if (!extensionPubkey) {
+      throw new Error("No NIP-07 extension detected.");
+    }
+    if (bunkerClientRef.current) {
+      bunkerClientRef.current.disconnect();
+      bunkerClientRef.current = null;
+    }
+    setSignerType("extension");
+    setPubkey(extensionPubkey);
+  }, [extensionPubkey]);
+
+  const signEvent = useCallback(
+    async (event, options = {}) => {
+      if (signerType === "bunker") {
+        if (!bunkerClientRef.current) {
+          throw new Error("Bunker signer not connected.");
+        }
+        return bunkerClientRef.current.signEvent(event, options);
+      }
+      if (signerType === "extension") {
+        if (!window?.nostr?.signEvent) {
+          throw new Error("Browser extension signer unavailable.");
+        }
+        return window.nostr.signEvent(event);
+      }
+      throw new Error("No signer connected.");
+    },
+    [signerType],
+  );
+
+  const contextValue = useMemo(
+    () => ({
+      pubkey,
+      signerType,
+      extensionPubkey,
+      connectBunker,
+      disconnectBunker,
+      useExtension,
+      signEvent,
+    }),
+    [
+      pubkey,
+      signerType,
+      extensionPubkey,
+      connectBunker,
+      disconnectBunker,
+      useExtension,
+      signEvent,
+    ],
+  );
+
   return (
-    <div className="main-container">
-      <h1 className="text-2xl font-bold mb-6">Schedule notes & other stuff</h1>
-      <div className="card">
-        <ComposeForm />
+    <SignerContext.Provider value={contextValue}>
+      <div className="main-container">
+        <h1 className="text-2xl font-bold mb-6">Schedule notes & other stuff</h1>
+        <div className="card">
+          <ComposeForm />
+        </div>
+        <div className="card">
+          <ScheduledList />
+        </div>
+        <footer className="mt-10 text-center text-sm text-gray-600">
+          Contributions and greetings •
+          <a
+            href="https://getalby.com/p/algorithm6028"
+            className="underline ml-1"
+          >
+            leon@nostr.aaroniumii.com
+          </a>
+        </footer>
       </div>
-      <div className="card">
-        <ScheduledList />
-      </div>
-      <footer className="mt-10 text-center text-sm text-gray-600">
-        Contributions and greetings •
-        <a
-          href="https://getalby.com/p/algorithm6028"
-          className="underline ml-1"
-        >
-          leon@nostr.aaroniumii.com
-        </a>
-      </footer>
-    </div>
+    </SignerContext.Provider>
   );
 }
 

--- a/frontend/src/components/ComposeForm.jsx
+++ b/frontend/src/components/ComposeForm.jsx
@@ -1,27 +1,79 @@
 // frontend/src/components/ComposeForm.jsx
-import React, { useEffect, useState } from "react";
-import { getEventHash } from "nostr-tools";
+import React, { useContext, useState } from "react";
+import { SignerContext } from "../App";
+
+function shortenHex(value) {
+  if (!value) {
+    return "";
+  }
+  return value.length > 16
+    ? `${value.slice(0, 8)}…${value.slice(-8)}`
+    : value;
+}
 
 export default function ComposeForm() {
+  const {
+    pubkey,
+    signerType,
+    extensionPubkey,
+    connectBunker,
+    disconnectBunker,
+    useExtension,
+    signEvent,
+  } = useContext(SignerContext);
   const [content, setContent] = useState("");
   const [datetime, setDatetime] = useState("");
   const [status, setStatus] = useState("");
-  const [pubkey, setPubkey] = useState("");
+  const [bunkerUrl, setBunkerUrl] = useState("");
+  const [bunkerStatus, setBunkerStatus] = useState("");
+  const [authUrl, setAuthUrl] = useState("");
 
-  useEffect(() => {
-    (async () => {
-      if (window.nostr) {
-        setPubkey(await window.nostr.getPublicKey());
-      } else {
-        setStatus("Please complete all fields and enable NIP-05.");
-      }
-    })();
-  }, []);
+  const handleConnectBunker = async () => {
+    if (!bunkerUrl.trim()) {
+      setBunkerStatus("Paste a bunker:// link to connect.");
+      return;
+    }
+    setBunkerStatus("Connecting to Bunker...");
+    setAuthUrl("");
+    try {
+      const connectedPubkey = await connectBunker(bunkerUrl.trim(), {
+        onAuthUrl: (url) => setAuthUrl(url),
+      });
+      setBunkerStatus(
+        `Connected to Bunker. Using signer ${shortenHex(connectedPubkey)}.`,
+      );
+      setStatus("");
+      setAuthUrl("");
+    } catch (err) {
+      console.error("Bunker connection failed", err);
+      setBunkerStatus(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const handleDisconnectBunker = () => {
+    disconnectBunker();
+    setBunkerStatus("Disconnected from Bunker.");
+    setAuthUrl("");
+  };
+
+  const handleUseExtension = () => {
+    try {
+      useExtension();
+      setBunkerStatus("Using browser extension for signing.");
+      setAuthUrl("");
+    } catch (err) {
+      setBunkerStatus(err instanceof Error ? err.message : String(err));
+    }
+  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    if (!content || !datetime || !window.nostr) {
-      setStatus("Please complete all fields and enable NIP-05.");
+    if (!content || !datetime) {
+      setStatus("Please complete all fields.");
+      return;
+    }
+    if (!pubkey || !signerType) {
+      setStatus("Connect a signer (extension or Bunker) before scheduling.");
       return;
     }
     if (new Date(datetime) <= new Date()) {
@@ -31,17 +83,16 @@ export default function ComposeForm() {
     try {
       const created_at = Math.floor(Date.now() / 1000);
       const event = { kind: 1, pubkey, created_at, tags: [], content };
-      event.id = getEventHash(event);
-      const signedEvent = await window.nostr.signEvent(event);
-
+      const signedEvent = await signEvent(event, {
+        onAuthUrl: (url) => setAuthUrl(url),
+      });
+      setAuthUrl("");
       const publishAtIso = new Date(datetime).toISOString();
-
       const res = await fetch("/schedule", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ event: signedEvent, publish_at: publishAtIso }),
       });
-
       if (res.ok) {
         setStatus("✅ Post scheduled successfully.");
         setContent("");
@@ -50,14 +101,91 @@ export default function ComposeForm() {
         setStatus("Error scheduling post.");
       }
     } catch (err) {
-      console.error(err);
-      setStatus("Error signing or sending post.");
+      console.error("Error signing or sending post", err);
+      setStatus(err instanceof Error ? err.message : "Error signing or sending post.");
     }
   };
 
+  const currentSignerLabel = (() => {
+    if (signerType === "bunker") {
+      return `Bunker remote signer (${shortenHex(pubkey)})`;
+    }
+    if (signerType === "extension") {
+      return `Browser extension (${shortenHex(pubkey)})`;
+    }
+    return "None";
+  })();
+
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      {/* Contenido de la nota */}
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="space-y-3">
+        <h2 className="text-lg font-semibold">Signer</h2>
+        <div className="border rounded p-4 space-y-3 bg-gray-50">
+          <p className="text-sm text-gray-700">
+            Current signer: <strong>{currentSignerLabel}</strong>
+          </p>
+          {extensionPubkey ? (
+            <button
+              type="button"
+              onClick={handleUseExtension}
+              className="text-sm px-3 py-1 rounded bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-60"
+              disabled={signerType === "extension"}
+            >
+              Use browser extension
+            </button>
+          ) : (
+            <p className="text-sm text-gray-600">
+              No NIP-07 browser extension detected.
+            </p>
+          )}
+          <div className="space-y-2">
+            <label className="block text-sm font-semibold">Bunker link</label>
+            <input
+              type="text"
+              value={bunkerUrl}
+              onChange={(e) => setBunkerUrl(e.target.value)}
+              placeholder="bunker://pubkey?relay=wss://...&secret=..."
+              className="w-full p-2 border rounded"
+            />
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="text-sm px-3 py-1 rounded bg-purple-600 text-white hover:bg-purple-700 disabled:opacity-60"
+                onClick={handleConnectBunker}
+                disabled={!bunkerUrl.trim()}
+              >
+                Connect Bunker
+              </button>
+              {signerType === "bunker" && (
+                <button
+                  type="button"
+                  className="text-sm px-3 py-1 rounded bg-gray-600 text-white hover:bg-gray-700"
+                  onClick={handleDisconnectBunker}
+                >
+                  Disconnect
+                </button>
+              )}
+            </div>
+            {bunkerStatus && (
+              <p className="text-xs text-gray-700">{bunkerStatus}</p>
+            )}
+            {authUrl && (
+              <p className="text-xs text-blue-700">
+                Approval required: {" "}
+                <a
+                  href={authUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline"
+                >
+                  open Amber to authorize
+                </a>
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+
       <div>
         <label className="block font-semibold">Content</label>
         <textarea
@@ -68,9 +196,8 @@ export default function ComposeForm() {
         />
       </div>
 
-      {/* Fecha y hora */}
       <div>
-        <label className="block font-semibold">Publish Date & Time</label>
+        <label className="block font-semibold">Publish Date &amp; Time</label>
         <input
           type="datetime-local"
           value={datetime}
@@ -79,7 +206,6 @@ export default function ComposeForm() {
         />
       </div>
 
-      {/* Botón de envío */}
       <button
         type="submit"
         className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
@@ -91,4 +217,3 @@ export default function ComposeForm() {
     </form>
   );
 }
-

--- a/frontend/src/components/ScheduledList.jsx
+++ b/frontend/src/components/ScheduledList.jsx
@@ -1,21 +1,22 @@
 // frontend/src/components/ScheduledList.jsx
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useContext, useEffect, useState } from "react";
+import { SignerContext } from "../App";
 
 export default function ScheduledList() {
+  const { pubkey } = useContext(SignerContext);
   const [events, setEvents] = useState([]);
   const [status, setStatus] = useState("");
   const [retryingId, setRetryingId] = useState(null);
-  const [listNotice, setListNotice] = useState("Loading scheduled posts...");
+  const [listNotice, setListNotice] = useState("Connect a signer to view scheduled posts.");
 
   const loadEvents = useCallback(async () => {
-    if (!window.nostr) {
+    if (!pubkey) {
       setEvents([]);
-      setListNotice("Connect a NIP-07 extension to view scheduled posts.");
+      setListNotice("Connect a signer to view scheduled posts.");
       return;
     }
     try {
       setListNotice("Loading scheduled posts...");
-      const pubkey = await window.nostr.getPublicKey();
       const res = await fetch(`/scheduled?pubkey=${pubkey}`);
       if (!res.ok) {
         throw new Error(`Request failed with status ${res.status}`);
@@ -28,7 +29,7 @@ export default function ScheduledList() {
       setEvents([]);
       setListNotice("Unable to load scheduled posts. Try again later.");
     }
-  }, []);
+  }, [pubkey]);
 
   useEffect(() => {
     loadEvents();
@@ -97,4 +98,3 @@ export default function ScheduledList() {
     </div>
   );
 }
-

--- a/frontend/src/lib/bunkerClient.js
+++ b/frontend/src/lib/bunkerClient.js
@@ -1,0 +1,283 @@
+import { SimplePool, finishEvent, generatePrivateKey, getPublicKey, nip19, nip44 } from "nostr-tools";
+
+const REMOTE_SIGNER_EVENT_KIND = 24133;
+const DEFAULT_TIMEOUT_MS = 15000;
+const DEFAULT_PERMISSIONS = ["sign_event:1"];
+
+function randomRequestId() {
+  if (typeof crypto !== "undefined" && crypto.getRandomValues) {
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  }
+  return Math.random().toString(16).slice(2);
+}
+
+function normalizeRemotePubkey(rawKey) {
+  if (!rawKey) {
+    throw new Error("The Bunker link must include the remote signer public key.");
+  }
+  const cleaned = rawKey.replace(/\/$/, "");
+  if (cleaned.startsWith("npub")) {
+    const decoded = nip19.decode(cleaned);
+    if (decoded.type !== "npub" || typeof decoded.data !== "string") {
+      throw new Error("Invalid npub value in the Bunker link.");
+    }
+    return decoded.data;
+  }
+  return cleaned.toLowerCase();
+}
+
+export function parseBunkerLink(link) {
+  if (!link || typeof link !== "string") {
+    throw new Error("Paste a valid Bunker link.");
+  }
+  let trimmed = link.trim();
+  if (!trimmed) {
+    throw new Error("Paste a valid Bunker link.");
+  }
+  if (!trimmed.includes("://")) {
+    trimmed = `bunker://${trimmed}`;
+  }
+  let url;
+  try {
+    url = new URL(trimmed);
+  } catch (err) {
+    throw new Error("Invalid Bunker link format.");
+  }
+  if (url.protocol !== "bunker:") {
+    throw new Error("The link must start with bunker://");
+  }
+  const hostPart = url.hostname || url.pathname.replace(/^\/+/, "");
+  const remoteSignerPubkey = normalizeRemotePubkey(hostPart);
+  if (!/^[0-9a-f]{64}$/i.test(remoteSignerPubkey)) {
+    throw new Error("Remote signer public key must be 64 hex characters.");
+  }
+  const relays = Array.from(new Set(url.searchParams.getAll("relay").map((entry) => entry.trim()).filter(Boolean)));
+  const filteredRelays = relays.filter((relay) => {
+    try {
+      const relayUrl = new URL(relay);
+      return relayUrl.protocol === "wss:" || relayUrl.protocol === "ws:";
+    } catch (err) {
+      return false;
+    }
+  });
+  if (!filteredRelays.length) {
+    throw new Error("The Bunker link must include at least one relay.");
+  }
+  const secret = url.searchParams.get("secret") || "";
+  return {
+    remoteSignerPubkey: remoteSignerPubkey.toLowerCase(),
+    relays: filteredRelays,
+    secret,
+  };
+}
+
+export default class BunkerClient {
+  constructor() {
+    this.pool = null;
+    this.sub = null;
+    this.pending = new Map();
+    this.relays = [];
+    this.remoteSignerPubkey = "";
+    this.secret = "";
+    this.clientSecretKey = "";
+    this.clientPubkey = "";
+    this.conversationKey = null;
+    this.userPubkey = "";
+  }
+
+  async connect(link, { onAuthUrl, permissions } = {}) {
+    this.disconnect();
+    const { remoteSignerPubkey, relays, secret } = parseBunkerLink(link);
+    this.remoteSignerPubkey = remoteSignerPubkey;
+    this.relays = relays;
+    this.secret = secret;
+    this.clientSecretKey = generatePrivateKey();
+    this.clientPubkey = getPublicKey(this.clientSecretKey);
+    this.conversationKey = nip44.utils.v2.getConversationKey(this.clientSecretKey, this.remoteSignerPubkey);
+    this.pool = new SimplePool();
+    this.sub = this.pool.sub(this.relays, [
+      { kinds: [REMOTE_SIGNER_EVENT_KIND], "#p": [this.clientPubkey] },
+    ]);
+    this.sub.on("event", (event) => this.handleIncomingEvent(event));
+    const requestedPermissions = Array.isArray(permissions) && permissions.length ? permissions : DEFAULT_PERMISSIONS;
+    const connectParams = [this.remoteSignerPubkey];
+    if (this.secret) {
+      connectParams.push(this.secret);
+    } else if (requestedPermissions.length) {
+      connectParams.push("");
+    }
+    if (requestedPermissions.length) {
+      connectParams.push(requestedPermissions.join(","));
+    }
+    try {
+      const connectResult = await this.sendRequest("connect", connectParams, { onAuthUrl });
+      if (this.secret && connectResult !== this.secret && connectResult !== "ack") {
+        throw new Error("Unexpected secret received from Bunker.");
+      }
+      const userPubkey = await this.sendRequest("get_public_key", [], { onAuthUrl });
+      if (!userPubkey || typeof userPubkey !== "string") {
+        throw new Error("Bunker did not provide a public key.");
+      }
+      this.userPubkey = userPubkey;
+      return userPubkey;
+    } catch (err) {
+      this.disconnect();
+      throw err;
+    }
+  }
+
+  async signEvent(event, { onAuthUrl, timeout } = {}) {
+    if (!this.conversationKey || !this.userPubkey) {
+      throw new Error("Bunker is not connected.");
+    }
+    const eventCopy = {
+      kind: event.kind,
+      content: event.content,
+      tags: Array.isArray(event.tags) ? event.tags : [],
+      created_at: event.created_at,
+      pubkey: this.userPubkey,
+    };
+    const payload = JSON.stringify(eventCopy);
+    const result = await this.sendRequest("sign_event", [payload], { onAuthUrl, timeout });
+    try {
+      return JSON.parse(result);
+    } catch (err) {
+      throw new Error("Invalid response received from Bunker.");
+    }
+  }
+
+  disconnect() {
+    if (this.sub) {
+      this.sub.unsub();
+      this.sub = null;
+    }
+    if (this.pool && this.relays.length) {
+      this.pool.close(this.relays);
+    }
+    this.pool = null;
+    this.relays = [];
+    this.remoteSignerPubkey = "";
+    this.secret = "";
+    this.clientSecretKey = "";
+    this.clientPubkey = "";
+    this.conversationKey = null;
+    this.userPubkey = "";
+    for (const pending of this.pending.values()) {
+      pending.reject(new Error("Bunker connection closed."));
+    }
+    this.pending.clear();
+  }
+
+  handleIncomingEvent(event) {
+    if (event.kind !== REMOTE_SIGNER_EVENT_KIND) {
+      return;
+    }
+    if (this.remoteSignerPubkey && event.pubkey !== this.remoteSignerPubkey) {
+      return;
+    }
+    if (!this.conversationKey) {
+      return;
+    }
+    let decrypted;
+    try {
+      decrypted = nip44.decrypt(this.conversationKey, event.content);
+    } catch (err) {
+      console.error("Unable to decrypt Bunker response", err);
+      return;
+    }
+    let message;
+    try {
+      message = JSON.parse(decrypted);
+    } catch (err) {
+      console.error("Invalid JSON received from Bunker", err);
+      return;
+    }
+    if (!message || typeof message.id !== "string") {
+      return;
+    }
+    const pending = this.pending.get(message.id);
+    if (!pending) {
+      return;
+    }
+    if (message.result === "auth_url" && typeof message.error === "string" && message.error) {
+      if (pending.onAuthUrl) {
+        pending.onAuthUrl(message.error);
+      }
+      return;
+    }
+    if (message.error) {
+      pending.reject(new Error(message.error));
+      return;
+    }
+    pending.resolve(typeof message.result === "string" ? message.result : "");
+  }
+
+  async sendRequest(method, params = [], { onAuthUrl, timeout } = {}) {
+    if (!this.pool || !this.conversationKey) {
+      throw new Error("Bunker is not connected.");
+    }
+    const requestId = randomRequestId();
+    const envelope = {
+      id: requestId,
+      method,
+      params,
+    };
+    const plaintext = JSON.stringify(envelope);
+    const content = nip44.encrypt(this.conversationKey, plaintext);
+    const event = finishEvent(
+      {
+        kind: REMOTE_SIGNER_EVENT_KIND,
+        created_at: Math.floor(Date.now() / 1000),
+        tags: [["p", this.remoteSignerPubkey]],
+        content,
+      },
+      this.clientSecretKey,
+    );
+    const effectiveTimeout = typeof timeout === "number" ? timeout : DEFAULT_TIMEOUT_MS;
+    return new Promise((resolve, reject) => {
+      const pending = {
+        settled: false,
+        onAuthUrl,
+        resolve: (value) => {
+          if (pending.settled) {
+            return;
+          }
+          pending.settled = true;
+          clearTimeout(timerId);
+          this.pending.delete(requestId);
+          resolve(value);
+        },
+        reject: (error) => {
+          if (pending.settled) {
+            return;
+          }
+          pending.settled = true;
+          clearTimeout(timerId);
+          this.pending.delete(requestId);
+          reject(error instanceof Error ? error : new Error(String(error)));
+        },
+      };
+      const timerId = setTimeout(() => {
+        pending.reject(new Error(`Bunker request \"${method}\" timed out.`));
+      }, effectiveTimeout);
+      this.pending.set(requestId, pending);
+      let publishPromises;
+      try {
+        publishPromises = this.pool.publish(this.relays, event);
+      } catch (err) {
+        pending.reject(err);
+        return;
+      }
+      Promise.allSettled(publishPromises).then((results) => {
+        const anyFulfilled = results.some((result) => result.status === "fulfilled");
+        if (!anyFulfilled) {
+          pending.reject(new Error("Unable to send request to any relay."));
+        }
+      }).catch((err) => {
+        pending.reject(err);
+      });
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add a NIP-46 Bunker client so users can paste Amber bunker:// links and sign remotely from the compose form
- share signer state across the app and let the scheduled list load events for the connected pubkey
- document the new Bunker login option in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcfa7c41cc832894f315f01cc28902